### PR TITLE
Add workaround for gerrit projects creation

### DIFF
--- a/files/etc/cloud/cloud.cfg
+++ b/files/etc/cloud/cloud.cfg
@@ -79,8 +79,11 @@ hostname: cfg01.try-mcp.local
 runcmd:
   - sed -i'.orig' -e's/PermitRootLogin.*/PermitRootLogin yes/g' -e's/PasswordAuthentication.*/PasswordAuthentication yes/g' /etc/ssh/sshd_config
   - service sshd restart
+  - sed -i 's/13306/3306/g' /srv/salt/reclass/classes/system/docker/swarm/stack/gerrit.yml
   - salt-call --timeout=120 test.ping
+  - salt-call saltutil.refresh_pillar
   - salt-call saltutil.sync_all
+  - salt-call reclass.validate_pillar
   - salt-call state.sls docker.swarm
   - sleep 60
   - salt-call state.sls nginx


### PR DESCRIPTION
Publish mysql to 3306 port as jeepyb doesn't
have an ability to use custom port for connection
to gerrit database.